### PR TITLE
feat(setup.py): add clean feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,47 @@
-from setuptools import setup
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+
+import glob
+import os
+from os.path import abspath, dirname, normpath
+import shutil
+from setuptools import setup, Command
+
+
+here = normpath(abspath(dirname(__file__)))
+
+
+class CleanCommand(Command):
+    """Custom clean command to tidy up the project root."""
+    CLEAN_FILES = './build ./dist ./*.pyc ./*.tgz src/*.egg-info'.split(' ')
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        global here
+
+        for path_spec in self.CLEAN_FILES:
+            # Make paths absolute and relative to this path
+            abs_paths = glob.glob(os.path.normpath(
+                os.path.join(here, path_spec)))
+            for path in [str(p) for p in abs_paths]:
+                if not path.startswith(here):
+                    # Die if path in CLEAN_FILES is absolute + outside this directory
+                    raise ValueError(
+                        "%s is not a path inside %s" % (path, here))
+                print('removing %s' % os.path.relpath(path))
+                shutil.rmtree(path)
+
 
 setup(
     name='powerline-k8sstatus',
@@ -23,5 +66,8 @@ setup(
     ],
     install_requires=[
         "kubernetes"
-    ]
+    ],
+    cmdclass={
+        'clean': CleanCommand,
+    }
 )


### PR DESCRIPTION
# SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #20 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

## COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`setup.py`

## ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add clean feature

<!--- Paste verbatim command output below, e.g. before and after your change -->
```py
class CleanCommand(Command):
    """Custom clean command to tidy up the project root."""
    CLEAN_FILES = './build ./dist ./*.pyc ./*.tgz src/*.egg-info'.split(' ')

    user_options = []

    def initialize_options(self):
        pass

    def finalize_options(self):
        pass

    def run(self):
        global here

        for path_spec in self.CLEAN_FILES:
            # Make paths absolute and relative to this path
            abs_paths = glob.glob(os.path.normpath(
                os.path.join(here, path_spec)))
            for path in [str(p) for p in abs_paths]:
                if not path.startswith(here):
                    # Die if path in CLEAN_FILES is absolute + outside this directory
                    raise ValueError(
                        "%s is not a path inside %s" % (path, here))
                print('removing %s' % os.path.relpath(path))
                shutil.rmtree(path)
```
