### PR TITLE
test(unit): add extra test for empty result and fix pyproject

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
   - setup.py
+  - tests/*

--- a/powerline_k8sstatus/segments.py
+++ b/powerline_k8sstatus/segments.py
@@ -12,7 +12,8 @@ from kubernetes import config
 class K8SStatusSegment(Segment):
     divider_highlight_group = None
 
-    def build_segments(self, context, namespace):
+    @staticmethod
+    def build_segments(context, namespace):
         segments = [{'contents': (u'\U00002388 {}').format(
             context), 'highlight_groups': ['k8sstatus']}]
 
@@ -35,7 +36,7 @@ class K8SStatusSegment(Segment):
 
         try:
             contexts, active_context = config.list_kube_config_contexts()
-        except config.config_exception.ConfigException:
+        except TypeError:
             return
 
         if not contexts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
-build-backend = "setuptools.build-meta"

--- a/tests/test_powerlinek8sstatus.py
+++ b/tests/test_powerlinek8sstatus.py
@@ -21,95 +21,111 @@ def mockk8sdefaultreturn():
     return ([{'context': {'cluster': 'minikube', 'namespace': 'default', 'user': CONTEXT}, 'name': 'minikube'}], {'context': {'cluster': 'minikube', 'namespace': 'default', 'user': 'minikube'}, 'name': CONTEXT})
 
 
-def mockk8snotnsreturn():
+def mockk8snotnamespacereturn():
     return ([{'context': {'cluster': 'minikube', 'user': 'minikube'}, 'name': CONTEXT}], {'context': {'cluster': 'minikube', 'user': 'minikube'}, 'name': CONTEXT})
 
 
-@pytest.fixture
+def mockk8snonereturn():
+    return None
+
+
+@ pytest.fixture
 def expected_symbol(request):
     return {'contents': (u'\U00002388 {}').format(
         CONTEXT), 'highlight_groups': [request.param]}
 
 
-@pytest.fixture
+@ pytest.fixture
 def pl():
     ''' Simulate the powerline logger '''
     logging.basicConfig()
     return logging.getLogger()
 
 
-@pytest.fixture
+@ pytest.fixture
 def segment_info():
     return {'environ': {}}
 
 
-@pytest.fixture
-def setup_nsmocked_context(monkeypatch):
+@ pytest.fixture
+def setup_namespacemocked_context(monkeypatch):
     monkeypatch.setattr(config, 'list_kube_config_contexts', mockk8sreturn)
 
 
-@pytest.fixture
+@ pytest.fixture
 def setup_mocked_context(monkeypatch):
     monkeypatch.setattr(config, 'list_kube_config_contexts',
                         mockk8sdefaultreturn)
 
 
-@pytest.fixture
-def setup_notnsmocked_context(monkeypatch):
+@ pytest.fixture
+def setup_notnamespacemocked_context(monkeypatch):
     monkeypatch.setattr(
-        config, 'list_kube_config_contexts', mockk8snotnsreturn)
+        config, 'list_kube_config_contexts', mockk8snotnamespacereturn)
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_nsmocked_context', 'expected_symbol')
+@ pytest.fixture
+def setup_nonemocked_context(monkeypatch):
+    monkeypatch.setattr(
+        config, 'list_kube_config_contexts', mockk8snonereturn)
+
+
+@ pytest.fixture
+def setup_missedmocked_context(monkeypatch):
+    monkeypatch.setattr(
+        config, 'list_kube_config_contexts', mockk8smissedfieldsreturn)
+
+
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_namespacemocked_context', 'expected_symbol')
 def test_cluster_notnamespace(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='')
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_nsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_namespacemocked_context', 'expected_symbol')
 def test_cluster_namespace(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='', show_namespace=True)
     assert output == [expected_symbol, EXPECTED_NAMESPACE]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_mocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_mocked_context', 'expected_symbol')
 def test_cluster_notnamespacedefault(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='')
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_mocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_mocked_context', 'expected_symbol')
 def test_cluster_notnamespacedefaulttrue(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='', show_namespace=True)
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_notnsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_notnamespacemocked_context', 'expected_symbol')
 def test_cluster_notnamespacdefined(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='')
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_notnsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_notnamespacemocked_context', 'expected_symbol')
 def test_cluster_notnamespacedefinedtrue(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='', show_namespace=True)
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_nsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_namespacemocked_context', 'expected_symbol')
 def test_envvar_notzero(pl, expected_symbol):
     segment_info = {'environ': {'POWERLINE_K8SSTATUS': '1'}}
     output = powerlinek8s.k8sstatus(
@@ -117,8 +133,8 @@ def test_envvar_notzero(pl, expected_symbol):
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_nsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_namespacemocked_context', 'expected_symbol')
 def test_envvar_notzeroempty(pl, expected_symbol):
     segment_info = {'environ': {}}
     output = powerlinek8s.k8sstatus(
@@ -126,8 +142,8 @@ def test_envvar_notzeroempty(pl, expected_symbol):
     assert output == [expected_symbol]
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_nsmocked_context', 'expected_symbol')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_namespacemocked_context', 'expected_symbol')
 def test_envvar_zero(pl, expected_symbol):
     segment_info = {'environ': {'POWERLINE_K8SSTATUS': '0'}}
     output = powerlinek8s.k8sstatus(
@@ -135,9 +151,25 @@ def test_envvar_zero(pl, expected_symbol):
     assert output is None
 
 
-@pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
-@pytest.mark.usefixtures('setup_mocked_context')
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_mocked_context')
 def test_no_items(pl, expected_symbol):
+    output = powerlinek8s.k8sstatus(
+        pl=pl, segment_info=segment_info, create_watcher='')
+    assert output is None
+
+
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_nonemocked_context', 'expected_symbol')
+def test_none_items(pl, segment_info, expected_symbol):
+    output = powerlinek8s.k8sstatus(
+        pl=pl, segment_info=segment_info, create_watcher='')
+    assert output is None
+
+
+@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
+@ pytest.mark.usefixtures('setup_nonemocked_context', 'expected_symbol')
+def test_none_items(pl, segment_info, expected_symbol):
     output = powerlinek8s.k8sstatus(
         pl=pl, segment_info=segment_info, create_watcher='')
     assert output is None


### PR DESCRIPTION
# SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #26 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

## COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unit tests

## ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
def mockk8snonereturn():
    return None

@ pytest.mark.parametrize('expected_symbol', ['k8sstatus'], indirect=True)
@ pytest.mark.usefixtures('setup_nonemocked_context', 'expected_symbol')
def test_none_items(pl, segment_info, expected_symbol):
    output = powerlinek8s.k8sstatus(
        pl=pl, segment_info=segment_info, create_watcher='')
    assert output is None

```
